### PR TITLE
Fixed typographical error, changed Ceasar to Caesar in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ciphers
 =======
 
-Vigenere / Vernam / Ceasar Ciphers solution to the mega project list done in Java. GUI elements are done in Swing.  
+Vigenere / Vernam / Caesar Ciphers solution to the mega project list done in Java. GUI elements are done in Swing.  
 Implementation of three well know ciphers which are Vigenere, Vernam, and Caesar.
 Screenshots: http://www.averageprogrammer.com/images/ciphersSS1.png, http://www.averageprogrammer.com/images/ciphersSS2.png,
 http://www.averageprogrammer.com/images/ciphersSS3.png, 


### PR DESCRIPTION
averageprogrammer, I've corrected a typographical error in the documentation of the [Ciphers](https://github.com/averageprogrammer/Ciphers) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
